### PR TITLE
Use more meaningful variable name for using debian binary for the upstream.

### DIFF
--- a/.ci.rosinstall.jade
+++ b/.ci.rosinstall.jade
@@ -1,0 +1,4 @@
+- git:
+    uri: https://github.com/ros-industrial/industrial_core.git
+    local-name: ros-industrial/industrial_core
+    version: jade

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,11 @@ env:
     # - env: ROS_DISTRO=indigo PRERELEASE=true  ## Comment out because this is meaningless for always failing without prerelease testable contents in industrial_ci.
     - ROS_DISTRO=indigo PRERELEASE=true PRERELEASE_REPONAME=industrial_core PRERELEASE_DOWNSTREAM_DEPTH=0
     - ROS_DISTRO=indigo APTKEY_STORE_SKS=hkp://ha.pool.sks-keyservers.vet  # Passing wrong SKS URL as a break test. Should still pass.
+    - ROS_DISTRO=indigo UPSTREAM_WORKSPACE=debian
+    - ROS_DISTRO=indigo UPSTREAM_WORKSPACE=file
+    - ROS_DISTRO=indigo UPSTREAM_WORKSPACE=source
+    - ROS_DISTRO=indigo USE_DEB=true  # Checking backup compatibility wity UPSTREAM_WORKSPACE
+    - ROS_DISTRO=indigo USE_DEB=false # Checking backup compatibility wity UPSTREAM_WORKSPACE
     - ROS_DISTRO=jade   APTKEY_STORE_SKS=hkp://ha.pool.sks-keyservers.vet  # Passing wrong SKS URL as a break test. Should still pass.
     - ROS_DISTRO=jade   PRERELEASE=true PRERELEASE_REPONAME=warehouse_ros PRERELEASE_DOWNSTREAM_DEPTH=1
     - ROS_DISTRO=kinetic

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,12 +19,13 @@ env:
     - ROS_DISTRO=indigo PRERELEASE=true PRERELEASE_REPONAME=industrial_core PRERELEASE_DOWNSTREAM_DEPTH=0
     - ROS_DISTRO=indigo APTKEY_STORE_SKS=hkp://ha.pool.sks-keyservers.vet  # Passing wrong SKS URL as a break test. Should still pass.
     - ROS_DISTRO=indigo UPSTREAM_WORKSPACE=debian
-    - ROS_DISTRO=indigo UPSTREAM_WORKSPACE=file
-    - ROS_DISTRO=indigo UPSTREAM_WORKSPACE=source
+    - ROS_DISTRO=indigo UPSTREAM_WORKSPACE=file  # Using default file name for ROSINSTALL_FILENAME
+    - ROS_DISTRO=indigo UPSTREAM_WORKSPACE=https://github.com/ros-industrial/industrial_ci/blob/master/.travis.rosinstall
     - ROS_DISTRO=indigo USE_DEB=true  # Checking backup compatibility wity UPSTREAM_WORKSPACE
     - ROS_DISTRO=indigo USE_DEB=false # Checking backup compatibility wity UPSTREAM_WORKSPACE
     - ROS_DISTRO=jade   APTKEY_STORE_SKS=hkp://ha.pool.sks-keyservers.vet  # Passing wrong SKS URL as a break test. Should still pass.
     - ROS_DISTRO=jade   PRERELEASE=true PRERELEASE_REPONAME=warehouse_ros PRERELEASE_DOWNSTREAM_DEPTH=1
+    - ROS_DISTRO=jade   UPSTREAM_WORKSPACE=file  ROSINSTALL_FILENAME=.ci.rosinstall  # Testing arbitrary file name, without ROS_DISTRO suffix.
     - ROS_DISTRO=kinetic
 matrix:
   allow_failures:

--- a/README.rst
+++ b/README.rst
@@ -127,8 +127,8 @@ Note that some of these currently tied only to a single option, but we still lea
 * `ROSINSTALL_FILENAME` (default: not set): See `UPSTREAM_WORKSPACE` description.
 * `ROSWS` (default: wstool): Currently only `wstool` is available.
 * `TARGET_PKGS` (default: not set): Used to fill `PKGS_DOWNSTREAM` if it is not set. If not set packages are set using the output of `catkin_topological_order` for the source space.
-* `UPSTREAM_WORKSPACE` (default: debian): 
-* `USE_DEB` (*DEPRECATED*: use `UPSTREAM_WORKSPACE` instead. default: true): When this is set `file`, the dependended packages that need to be built from source are downloaded based on a `.rosinstall` file in your repository. Use `$ROSINSTALL_FILENAME` to specify the file name. See more in `this section <https://github.com/ros-industrial/industrial_ci/blob/master/README.rst#optional-build-depended-packages-from-source>`_.
+* `UPSTREAM_WORKSPACE` (default: debian): When this is set `file`, the dependended packages that need to be built from source are downloaded based on a `.rosinstall` file in your repository. Use `$ROSINSTALL_FILENAME` to specify the file name. See more in `this section <https://github.com/ros-industrial/industrial_ci/blob/master/README.rst#optional-build-depended-packages-from-source>`_.
+* `USE_DEB` (*DEPRECATED*: use `UPSTREAM_WORKSPACE` instead. default: true): if `true`, `UPSTREAM_WORKSPACE` will be set as `debian`. if `false`, `file` will be set. See `UPSTREAM_WORKSPACE` section for more info.
 
 Note: You see some `*PKGS*` variables. These make things very flexible but in normal usecases you don't need to be bothered with them - just keep them blank.
 

--- a/README.rst
+++ b/README.rst
@@ -127,7 +127,8 @@ Note that some of these currently tied only to a single option, but we still lea
 * `ROSINSTALL_FILENAME` (default: not set): See `USE_DEB` description.
 * `ROSWS` (default: wstool): Currently only `wstool` is available.
 * `TARGET_PKGS` (default: not set): Used to fill `PKGS_DOWNSTREAM` if it is not set. If not set packages are set using the output of `catkin_topological_order` for the source space.
-* `USE_DEB` (default: true): When this is set `false`, the dependended packages that need to be built from source are downloaded based on file `$ROSINSTALL_FILENAME` in your repository. See more in `this section <https://github.com/ros-industrial/industrial_ci/blob/master/README.rst#optional-build-depended-packages-from-source>`_.
+* `UPSTREAM_WORKSPACE` (default: debian): 
+* `USE_DEB` (*DEPRECATED*: use `UPSTREAM_WORKSPACE` instead. default: true): When this is set `false`, the dependended packages that need to be built from source are downloaded based on file `$ROSINSTALL_FILENAME` in your repository. See more in `this section <https://github.com/ros-industrial/industrial_ci/blob/master/README.rst#optional-build-depended-packages-from-source>`_.
 
 Note: You see some `*PKGS*` variables. These make things very flexible but in normal usecases you don't need to be bothered with them - just keep them blank.
 
@@ -243,7 +244,7 @@ By default the packages your package depend upon are installed via binaries. How
 Use .rosinstall file to specify the depended packages source repository
 +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
-Standard way is 1) set `USE_DEB` as `false`, 2) create a file `$ROSINSTALL_FILENAME` using `the same file format as .rosinstall <http://docs.ros.org/independent/api/rosinstall/html/rosinstall_file_format.html>`_ and place it at the top level directory of your package.
+Standard way is 1) set `UPSTREAM_WORKSPACE` as `file`, 2) create a file `$ROSINSTALL_FILENAME` using `the same file format as .rosinstall <http://docs.ros.org/independent/api/rosinstall/html/rosinstall_file_format.html>`_ and place it at the top level directory of your package.
 
 Have multiple .rosinstall files per ROS-distro
 ++++++++++++++++++++++++++++++++++++++++++++++
@@ -253,7 +254,7 @@ By adding `.$ROS_DISTRO` suffix to your `$ROSINSTALL_FILENAME` file, you can spe
 Use .rosinstall from external location
 ++++++++++++++++++++++++++++++++++++++++++++++
 
-You can utilize `.rosinstall` file stored anywhere as long as its location is URL specifyable. To do so, set its URL directly to `USE_DEB`.
+You can utilize `.rosinstall` file stored anywhere as long as its location is URL specifyable. To do so, set its URL directly to `UPSTREAM_WORKSPACE`.
 
 For maintainers of industrial_ci repository
 ================================================

--- a/README.rst
+++ b/README.rst
@@ -124,11 +124,11 @@ Note that some of these currently tied only to a single option, but we still lea
 * `PKGS_DOWNSTREAM` (default: explained): Packages in downstream to be tested. By default, `TARGET_PKGS` is used if set, if not then `BUILD_PKGS` is used.
 * `ROS_PARALLEL_JOBS` (default: -j8): Maximum number of packages to be built in parallel by the underlining build tool. As of Jan 2016, this is only enabled with `catkin_tools` (with `make` as an underlining builder).
 * `ROS_PARALLEL_TEST_JOBS` (default: -j8): Maximum number of packages which could be examined in parallel during the test run by the underlining build tool. If not set it's filled by `ROS_PARALLEL_JOBS`. As of Jan 2016, this is only enabled with `catkin_tools` (with `make` as an underlining builder).
-* `ROSINSTALL_FILENAME` (default: not set): See `USE_DEB` description.
+* `ROSINSTALL_FILENAME` (default: not set): See `UPSTREAM_WORKSPACE` description.
 * `ROSWS` (default: wstool): Currently only `wstool` is available.
 * `TARGET_PKGS` (default: not set): Used to fill `PKGS_DOWNSTREAM` if it is not set. If not set packages are set using the output of `catkin_topological_order` for the source space.
 * `UPSTREAM_WORKSPACE` (default: debian): 
-* `USE_DEB` (*DEPRECATED*: use `UPSTREAM_WORKSPACE` instead. default: true): When this is set `false`, the dependended packages that need to be built from source are downloaded based on file `$ROSINSTALL_FILENAME` in your repository. See more in `this section <https://github.com/ros-industrial/industrial_ci/blob/master/README.rst#optional-build-depended-packages-from-source>`_.
+* `USE_DEB` (*DEPRECATED*: use `UPSTREAM_WORKSPACE` instead. default: true): When this is set `file`, the dependended packages that need to be built from source are downloaded based on a `.rosinstall` file in your repository. Use `$ROSINSTALL_FILENAME` to specify the file name. See more in `this section <https://github.com/ros-industrial/industrial_ci/blob/master/README.rst#optional-build-depended-packages-from-source>`_.
 
 Note: You see some `*PKGS*` variables. These make things very flexible but in normal usecases you don't need to be bothered with them - just keep them blank.
 
@@ -239,22 +239,35 @@ Then open a pull request using this branch against the branch that the change is
 (Optional) Build depended packages from source
 ----------------------------------------------
 
-By default the packages your package depend upon are installed via binaries. However, you may want to build them via source in some cases (e.g. binaries are not available). There is a way to do so.
+By default the packages your package depend upon are installed via binaries. However, you may want to build them via source in some cases (e.g. when depended binaries are not available). There are a few ways to do so in `industrial_ci`. Examples of all are available in `.travis.yml file on this repository <https://github.com/ros-industrial/industrial_ci/blob/master/.travis.yml>`_.
 
 Use .rosinstall file to specify the depended packages source repository
 +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
-Standard way is 1) set `UPSTREAM_WORKSPACE` as `file`, 2) create a file `$ROSINSTALL_FILENAME` using `the same file format as .rosinstall <http://docs.ros.org/independent/api/rosinstall/html/rosinstall_file_format.html>`_ and place it at the top level directory of your package.
+Standard way is 1) set `UPSTREAM_WORKSPACE` as `file`, 2) create a file `$ROSINSTALL_FILENAME` using the same file format as `.rosinstall <http://docs.ros.org/independent/api/rosinstall/html/rosinstall_file_format.html>`_ and place it at the top level directory of your package.
 
 Have multiple .rosinstall files per ROS-distro
 ++++++++++++++++++++++++++++++++++++++++++++++
 
-By adding `.$ROS_DISTRO` suffix to your `$ROSINSTALL_FILENAME` file, you can specify which file to use per your `$ROS_DISTRO`. E.g. `$ROSINSTALL_FILENAME.$ROS_DISTRO`.
+By adding `.$ROS_DISTRO` suffix to your `$ROSINSTALL_FILENAME` file, you can specify which file to use per your `$ROS_DISTRO`. So the syntax of the file name for this purpose is `$ROSINSTALL_FILENAME.$ROS_DISTRO`.
+For example, let's say you want to test multiple distros (indigo, jade) and you have `.travis.rosinstall` and `.travis.rosinstall.jade` files in your repo. You can define the Travis config as:
+
+::
+
+    env:
+      matrix:
+
+        - ROS_DISTRO=indigo UPSTREAM_WORKSPACE=file
+        - ROS_DISTRO=jade   UPSTREAM_WORKSPACE=file
+
+With this config, for indigo default file name `.travis.rosinstall` will be seached and used if found. For jade, the file that consists of the default file name plus `.jade` suffix will be prioritized.
+
+When `$ROSINSTALL_FILENAME.$ROS_DISTRO` file isn't found, `$ROSINSTALL_FILENAME` will be used for all jobs that define `UPSTREAM_WORKSPACE`.
 
 Use .rosinstall from external location
 ++++++++++++++++++++++++++++++++++++++++++++++
 
-You can utilize `.rosinstall` file stored anywhere as long as its location is URL specifyable. To do so, set its URL directly to `UPSTREAM_WORKSPACE`.
+You can utilize `.rosinstall` file stored anywhere as long as its location is URL specifyable. To do so, set its complete path URL directly to `UPSTREAM_WORKSPACE`.
 
 For maintainers of industrial_ci repository
 ================================================

--- a/travis.sh
+++ b/travis.sh
@@ -99,6 +99,7 @@ if [ ! "$ROSINSTALL_FILENAME" ]; then export ROSINSTALL_FILENAME=".travis.rosins
 if [ ! "$APTKEY_STORE_HTTPS" ]; then export APTKEY_STORE_HTTPS="https://raw.githubusercontent.com/ros/rosdistro/master/ros.key"; fi
 if [ ! "$APTKEY_STORE_SKS" ]; then export APTKEY_STORE_SKS="hkp://ha.pool.sks-keyservers.net"; fi  # Export a variable for SKS URL for break-testing purpose.
 if [ ! "$HASHKEY_SKS" ]; then export HASHKEY_SKS="0xB01FA116"; fi
+if [ "$USE_DEB" ]; then export UPSTREAM_WORKSPACE="USE_DEB"; fi  # USE_DEB is deprecated. See https://github.com/ros-industrial/industrial_ci/pull/47#discussion_r64882878 for the discussion.
 
 echo "Testing branch $TRAVIS_BRANCH of $DOWNSTREAM_REPO_NAME"
 # Set apt repo
@@ -156,8 +157,11 @@ travis_time_start setup_rosws
 # Create workspace
 mkdir -p ~/ros/ws_$DOWNSTREAM_REPO_NAME/src
 cd ~/ros/ws_$DOWNSTREAM_REPO_NAME/src
-case "$USE_DEB" in
-false) # When USE_DEB is false, the dependended packages that need to be built from source are downloaded based on $ROSINSTALL_FILENAME file.
+case "$UPSTREAM_WORKSPACE" in
+debian)
+   echo "Obtain deb binary for upstream packages."
+   ;;
+file) # When UPSTREAM_WORKSPACE is false, the dependended packages that need to be built from source are downloaded based on $ROSINSTALL_FILENAME file.
    $ROSWS init .
    if [ -e $CI_SOURCE_PATH/$ROSINSTALL_FILENAME ]; then
        # install (maybe unreleased version) dependencies from source
@@ -168,9 +172,9 @@ false) # When USE_DEB is false, the dependended packages that need to be built f
        $ROSWS merge file://$CI_SOURCE_PATH/$ROSINSTALL_FILENAME.$ROS_DISTRO
    fi
    ;;
-http://* | https://*) # When USE_DEB is an http url, use it directly
+http://* | https://*) # When UPSTREAM_WORKSPACE is an http url, use it directly
    $ROSWS init .
-   $ROSWS merge $USE_DEB
+   $ROSWS merge $UPSTREAM_WORKSPACE
    ;;
 esac
 

--- a/travis.sh
+++ b/travis.sh
@@ -99,7 +99,12 @@ if [ ! "$ROSINSTALL_FILENAME" ]; then export ROSINSTALL_FILENAME=".travis.rosins
 if [ ! "$APTKEY_STORE_HTTPS" ]; then export APTKEY_STORE_HTTPS="https://raw.githubusercontent.com/ros/rosdistro/master/ros.key"; fi
 if [ ! "$APTKEY_STORE_SKS" ]; then export APTKEY_STORE_SKS="hkp://ha.pool.sks-keyservers.net"; fi  # Export a variable for SKS URL for break-testing purpose.
 if [ ! "$HASHKEY_SKS" ]; then export HASHKEY_SKS="0xB01FA116"; fi
-if [ "$USE_DEB" ]; then export UPSTREAM_WORKSPACE=$USE_DEB; else export UPSTREAM_WORKSPACE="debian" fi  # USE_DEB is deprecated. See https://github.com/ros-industrial/industrial_ci/pull/47#discussion_r64882878 for the discussion.
+if [ "$USE_DEB" ]; then  # USE_DEB is deprecated. See https://github.com/ros-industrial/industrial_ci/pull/47#discussion_r64882878 for the discussion.
+    if [ "$USE_DEB" != "true" ]; then export UPSTREAM_WORKSPACE="file";
+    else export UPSTREAM_WORKSPACE="debian";
+    fi
+fi
+if [ ! "$UPSTREAM_WORKSPACE" ]; then export UPSTREAM_WORKSPACE="debian"; fi
 
 echo "Testing branch $TRAVIS_BRANCH of $DOWNSTREAM_REPO_NAME"
 # Set apt repo

--- a/travis.sh
+++ b/travis.sh
@@ -159,31 +159,31 @@ mkdir -p ~/ros/ws_$DOWNSTREAM_REPO_NAME/src
 cd ~/ros/ws_$DOWNSTREAM_REPO_NAME/src
 case "$UPSTREAM_WORKSPACE" in
 debian)
-   echo "Obtain deb binary for upstream packages."
-   ;;
+    echo "Obtain deb binary for upstream packages."
+    ;;
 file) # When UPSTREAM_WORKSPACE is file, the dependended packages that need to be built from source are downloaded based on $ROSINSTALL_FILENAME file.
-   $ROSWS init .
-   # Prioritize $ROSINSTALL_FILENAME.$ROS_DISTRO if it exists over $ROSINSTALL_FILENAME.
-   if [ -e $CI_SOURCE_PATH/$ROSINSTALL_FILENAME.$ROS_DISTRO ]; then
-       # install (maybe unreleased version) dependencies from source for specific ros version
-       $ROSWS merge file://$CI_SOURCE_PATH/$ROSINSTALL_FILENAME.$ROS_DISTRO
-   fi
-   elif [ -e $CI_SOURCE_PATH/$ROSINSTALL_FILENAME ]; then
-       # install (maybe unreleased version) dependencies from source
-       $ROSWS merge file://$CI_SOURCE_PATH/$ROSINSTALL_FILENAME
-   fi
-   ;;
+    $ROSWS init .
+    # Prioritize $ROSINSTALL_FILENAME.$ROS_DISTRO if it exists over $ROSINSTALL_FILENAME.
+    if [ -e $CI_SOURCE_PATH/$ROSINSTALL_FILENAME.$ROS_DISTRO ]; then
+        # install (maybe unreleased version) dependencies from source for specific ros version
+        $ROSWS merge file://$CI_SOURCE_PATH/$ROSINSTALL_FILENAME.$ROS_DISTRO
+    fi
+    elif [ -e $CI_SOURCE_PATH/$ROSINSTALL_FILENAME ]; then
+        # install (maybe unreleased version) dependencies from source
+        $ROSWS merge file://$CI_SOURCE_PATH/$ROSINSTALL_FILENAME
+    fi
+    ;;
 http://* | https://*) # When UPSTREAM_WORKSPACE is an http url, use it directly
-   $ROSWS init .
-   $ROSWS merge $UPSTREAM_WORKSPACE
-   ;;
+    $ROSWS init .
+    $ROSWS merge $UPSTREAM_WORKSPACE
+    ;;
 esac
 
 # download upstream packages into workspace
 if [ -e .rosinstall ]; then
-   # ensure that the downstream is not in .rosinstall
-   $ROSWS rm $DOWNSTREAM_REPO_NAME || true
-   $ROSWS update
+    # ensure that the downstream is not in .rosinstall
+    $ROSWS rm $DOWNSTREAM_REPO_NAME || true
+    $ROSWS update
 fi
 # CI_SOURCE_PATH is the path of the downstream repository that we are testing. Link it to the catkin workspace
 ln -s $CI_SOURCE_PATH .

--- a/travis.sh
+++ b/travis.sh
@@ -163,13 +163,14 @@ debian)
    ;;
 file) # When UPSTREAM_WORKSPACE is file, the dependended packages that need to be built from source are downloaded based on $ROSINSTALL_FILENAME file.
    $ROSWS init .
-   if [ -e $CI_SOURCE_PATH/$ROSINSTALL_FILENAME ]; then
-       # install (maybe unreleased version) dependencies from source
-       $ROSWS merge file://$CI_SOURCE_PATH/$ROSINSTALL_FILENAME
-   fi
+   # Prioritize $ROSINSTALL_FILENAME.$ROS_DISTRO if it exists over $ROSINSTALL_FILENAME.
    if [ -e $CI_SOURCE_PATH/$ROSINSTALL_FILENAME.$ROS_DISTRO ]; then
        # install (maybe unreleased version) dependencies from source for specific ros version
        $ROSWS merge file://$CI_SOURCE_PATH/$ROSINSTALL_FILENAME.$ROS_DISTRO
+   fi
+   elif [ -e $CI_SOURCE_PATH/$ROSINSTALL_FILENAME ]; then
+       # install (maybe unreleased version) dependencies from source
+       $ROSWS merge file://$CI_SOURCE_PATH/$ROSINSTALL_FILENAME
    fi
    ;;
 http://* | https://*) # When UPSTREAM_WORKSPACE is an http url, use it directly

--- a/travis.sh
+++ b/travis.sh
@@ -99,7 +99,7 @@ if [ ! "$ROSINSTALL_FILENAME" ]; then export ROSINSTALL_FILENAME=".travis.rosins
 if [ ! "$APTKEY_STORE_HTTPS" ]; then export APTKEY_STORE_HTTPS="https://raw.githubusercontent.com/ros/rosdistro/master/ros.key"; fi
 if [ ! "$APTKEY_STORE_SKS" ]; then export APTKEY_STORE_SKS="hkp://ha.pool.sks-keyservers.net"; fi  # Export a variable for SKS URL for break-testing purpose.
 if [ ! "$HASHKEY_SKS" ]; then export HASHKEY_SKS="0xB01FA116"; fi
-if [ "$USE_DEB" ]; then export UPSTREAM_WORKSPACE="USE_DEB"; fi  # USE_DEB is deprecated. See https://github.com/ros-industrial/industrial_ci/pull/47#discussion_r64882878 for the discussion.
+if [ "$USE_DEB" ]; then export UPSTREAM_WORKSPACE=$USE_DEB; else export UPSTREAM_WORKSPACE="debian" fi  # USE_DEB is deprecated. See https://github.com/ros-industrial/industrial_ci/pull/47#discussion_r64882878 for the discussion.
 
 echo "Testing branch $TRAVIS_BRANCH of $DOWNSTREAM_REPO_NAME"
 # Set apt repo
@@ -161,7 +161,7 @@ case "$UPSTREAM_WORKSPACE" in
 debian)
    echo "Obtain deb binary for upstream packages."
    ;;
-file) # When UPSTREAM_WORKSPACE is false, the dependended packages that need to be built from source are downloaded based on $ROSINSTALL_FILENAME file.
+file) # When UPSTREAM_WORKSPACE is file, the dependended packages that need to be built from source are downloaded based on $ROSINSTALL_FILENAME file.
    $ROSWS init .
    if [ -e $CI_SOURCE_PATH/$ROSINSTALL_FILENAME ]; then
        # install (maybe unreleased version) dependencies from source


### PR DESCRIPTION
Implementing what's suggested in https://github.com/ros-industrial/industrial_ci/pull/47#discussion_r64882878

`USE_DEB` is still kept for backward compatibility.